### PR TITLE
Flow "primitive" typo

### DIFF
--- a/syntaxes/Babel Language.json
+++ b/syntaxes/Babel Language.json
@@ -1773,7 +1773,7 @@
             "comment": "primitive flowtypes",
             "match": "\\s*\\b((?>any|boolean|mixed|number|string|void))\\b",
             "captures": {
-              "1": { "name": "support.type.builtin.primitve.flowtype" }
+              "1": { "name": "support.type.builtin.primitive.flowtype" }
             }
           },
           {


### PR DESCRIPTION
There was a super simple typo, I found it while creating selectors for my theme and thought I might as well make a PR since it's super simple.